### PR TITLE
capital city names now red for differentiation

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -156,8 +156,10 @@ def city_name(context, layout, tilepair):
     pos = cubic.cube_to_pixel(layout, cube)
     x = pos.x
     y = pos.y - layout.size.y * 1.15
-
-    text(context, layout, tile.locality.name, round(x), round(y), 100)
+    if tile.locality.category == "Capital":
+        text(context, layout, tile.locality.name, round(x), round(y), 100, color=0xFF0000)
+    else:
+        text(context, layout, tile.locality.name, round(x), round(y), 100)
 
 def army_info_text(context, layout, tilepair):
     coord, tile = tilepair


### PR DESCRIPTION
capital city names are red when scrolled over, allows for the player to see and target enemy capitals (like the AI does), captured capitals remain red so no way for a player to differentiate between a enemy actual capital and a captured capital